### PR TITLE
Fix #36: Fix clippy warnings in tree.rs, comments.rs, and main.rs

### DIFF
--- a/src/comments.rs
+++ b/src/comments.rs
@@ -61,12 +61,11 @@ fn extract_rust_comment(content: &str) -> Option<String> {
             in_doc_comment = true;
             let comment = trimmed.strip_prefix("///").unwrap_or("").trim();
             doc_lines.push(comment);
-        } else if in_doc_comment {
-            break;
-        } else if !trimmed.is_empty()
-            && !trimmed.starts_with("//")
-            && !trimmed.starts_with("#[")
-            && !trimmed.starts_with("#![")
+        } else if in_doc_comment
+            || (!trimmed.is_empty()
+                && !trimmed.starts_with("//")
+                && !trimmed.starts_with("#[")
+                && !trimmed.starts_with("#!["))
         {
             break;
         }
@@ -350,10 +349,10 @@ fn extract_javadoc_comment(content: &str) -> Option<String> {
 fn extract_php_comment(content: &str) -> Option<String> {
     // Skip <?php tag
     let content = content.trim_start();
-    let content = if content.starts_with("<?php") {
-        &content[5..]
-    } else if content.starts_with("<?") {
-        &content[2..]
+    let content = if let Some(stripped) = content.strip_prefix("<?php") {
+        stripped
+    } else if let Some(stripped) = content.strip_prefix("<?") {
+        stripped
     } else {
         content
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,15 +202,12 @@ fn main() {
             }
         }
 
-        let metadata_config = {
-            let config = MetadataConfig {
-                comments: show_comments,
-                types: show_types,
-                full: full_mode,
-                prefix: args.prefix.clone(),
-                order: get_metadata_order(&matches),
-            };
-            config
+        let metadata_config = MetadataConfig {
+            comments: show_comments,
+            types: show_types,
+            full: full_mode,
+            prefix: args.prefix.clone(),
+            order: get_metadata_order(&matches),
         };
 
         let output_config = OutputConfig {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -118,7 +118,7 @@ impl TreeWalker {
             return None;
         }
 
-        let at_max_depth = self.config.max_depth.map_or(false, |max| depth >= max);
+        let at_max_depth = self.config.max_depth.is_some_and(|max| depth >= max);
 
         let name = path
             .file_name()
@@ -171,7 +171,7 @@ impl TreeWalker {
         };
 
         let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
-        entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        entries.sort_by_key(|a| a.file_name());
 
         for entry in entries {
             let entry_path = entry.path();
@@ -468,7 +468,7 @@ impl StreamingWalker {
         };
 
         let mut dir_entries: Vec<_> = dir_entries.filter_map(|e| e.ok()).collect();
-        dir_entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        dir_entries.sort_by_key(|a| a.file_name());
 
         // Filter entries
         let filtered_entries: Vec<_> = dir_entries
@@ -516,10 +516,11 @@ impl StreamingWalker {
                     continue;
                 }
                 valid_entries.push((entry, false)); // false = is file
-            } else if entry_path.is_dir() && !entry_path.is_symlink() {
-                if self.config.dirs_only || self.has_included_files(&entry_path) {
-                    valid_entries.push((entry, true)); // true = is directory
-                }
+            } else if entry_path.is_dir()
+                && !entry_path.is_symlink()
+                && (self.config.dirs_only || self.has_included_files(&entry_path))
+            {
+                valid_entries.push((entry, true)); // true = is directory
             }
         }
 
@@ -578,7 +579,7 @@ impl StreamingWalker {
             return Ok(None);
         }
 
-        let at_max_depth = self.config.max_depth.map_or(false, |max| depth >= max);
+        let at_max_depth = self.config.max_depth.is_some_and(|max| depth >= max);
 
         // Files are handled by their parent directory iteration
         if path.is_file() || !path.is_dir() {
@@ -592,7 +593,7 @@ impl StreamingWalker {
         };
 
         let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
-        entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        entries.sort_by_key(|a| a.file_name());
 
         // Filter entries first to know which ones will be included
         let filtered_entries: Vec<_> = entries


### PR DESCRIPTION
## Summary

- Use `is_some_and` instead of `map_or(false, ...)` for cleaner code
- Use `sort_by_key` instead of `sort_by` for simpler sorting
- Collapse nested if statement in `collect_entries`
- Combine identical if branches in `extract_rust_comment`
- Use `strip_prefix` instead of manual slicing in `extract_php_comment`
- Remove unnecessary let binding in `main.rs`

## Test plan

- [x] `cargo clippy` passes without warnings
- [x] `cargo test` passes
- [x] `cargo fmt` applied