### PR TITLE
Fix #34: Remove unused repo field from GitFilter struct

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -112,8 +112,6 @@ impl GitignoreFilter {
 /// Filter based on git tracking status (files in the git index).
 /// Use this with --tracked flag to show only git-tracked files.
 pub struct GitFilter {
-    #[allow(dead_code)]
-    repo: Repository,
     tracked_files: HashSet<PathBuf>,
     tracked_dirs: HashSet<PathBuf>,
     repo_root: PathBuf,
@@ -139,7 +137,6 @@ impl GitFilter {
         }
 
         Some(Self {
-            repo,
             tracked_files,
             tracked_dirs,
             repo_root,


### PR DESCRIPTION
## Summary

- Remove unused `repo` field from `GitFilter` struct
- The `Repository` object was only used during initialization in `collect_tracked_files()` but stored unnecessarily
- Removes the `#[allow(dead_code)]` annotation and frees the git repository handle

## Test plan

- [x] `cargo clippy` passes without warnings
- [x] `cargo test` passes
- [x] `cargo fmt` applied