### PR TITLE
Fix #31: Deduplicate test repository setup code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "criterion",
+ "fruit",
  "git2",
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ keywords = ["tree", "cli", "git", "directory"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
 
+[features]
+default = []
+test-utils = ["dep:tempfile"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 git2 = "0.19"
@@ -19,12 +23,14 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 termcolor = "1.4"
+tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
-criterion = "0.5"
+criterion = { version = "0.5", features = ["html_reports"] }
+fruit = { path = ".", features = ["test-utils"] }
 
 [[bench]]
 name = "benchmarks"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ pub mod output;
 pub mod tree;
 pub mod types;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
 pub use comments::extract_first_comment;
 pub use git::{GitFilter, GitignoreFilter};
 pub use metadata::{

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,125 @@
+//! Test utilities for creating temporary git repositories.
+//!
+//! This module is only compiled for tests and benchmarks.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// A temporary git repository for testing.
+///
+/// Provides methods for creating files, git initialization, and staging files.
+/// The repository is automatically cleaned up when dropped.
+pub struct TestRepo {
+    dir: TempDir,
+    git_initialized: bool,
+}
+
+impl TestRepo {
+    /// Create a new empty temporary directory.
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        Self {
+            dir,
+            git_initialized: false,
+        }
+    }
+
+    /// Create a new temporary directory with git initialized.
+    pub fn with_git() -> Self {
+        let mut repo = Self::new();
+        repo.init_git();
+        repo
+    }
+
+    /// Get the path to the temporary directory.
+    pub fn path(&self) -> &Path {
+        self.dir.path()
+    }
+
+    /// Initialize a git repository in the temporary directory.
+    ///
+    /// Also configures user.email and user.name for commits.
+    pub fn init_git(&mut self) {
+        Command::new("git")
+            .args(["init"])
+            .current_dir(self.dir.path())
+            .output()
+            .expect("Failed to init git");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(self.dir.path())
+            .output()
+            .expect("Failed to set git email");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(self.dir.path())
+            .output()
+            .expect("Failed to set git name");
+
+        self.git_initialized = true;
+    }
+
+    /// Add a file and stage it if git is initialized.
+    ///
+    /// Creates parent directories as needed.
+    pub fn add_file(&self, path: &str, content: &str) -> PathBuf {
+        let full_path = self.dir.path().join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create parent dirs");
+        }
+        fs::write(&full_path, content).expect("Failed to write file");
+
+        if self.git_initialized {
+            Command::new("git")
+                .args(["add", path])
+                .current_dir(self.dir.path())
+                .output()
+                .expect("Failed to git add");
+        }
+
+        full_path
+    }
+
+    /// Add a file without staging it.
+    ///
+    /// Creates parent directories as needed.
+    pub fn add_untracked(&self, path: &str, content: &str) -> PathBuf {
+        let full_path = self.dir.path().join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create parent dirs");
+        }
+        fs::write(&full_path, content).expect("Failed to write file");
+        full_path
+    }
+
+    /// Stage all files in the repository.
+    pub fn stage_all(&self) {
+        if self.git_initialized {
+            Command::new("git")
+                .args(["add", "."])
+                .current_dir(self.dir.path())
+                .output()
+                .expect("Failed to git add");
+        }
+    }
+
+    /// Create a commit with the given message.
+    pub fn commit(&self, message: &str) {
+        assert!(self.git_initialized, "Git not initialized");
+        Command::new("git")
+            .args(["commit", "-m", message, "--allow-empty"])
+            .current_dir(self.dir.path())
+            .output()
+            .expect("Failed to commit");
+    }
+}
+
+impl Default for TestRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,92 +1,12 @@
 //! Test harness for fruit integration tests
+//!
+//! Re-exports TestRepo from fruit::test_utils and provides run_fruit helper.
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
-use tempfile::TempDir;
 
-pub struct TestRepo {
-    dir: TempDir,
-    git_initialized: bool,
-}
-
-impl TestRepo {
-    pub fn new() -> Self {
-        let dir = TempDir::new().expect("Failed to create temp dir");
-        Self {
-            dir,
-            git_initialized: false,
-        }
-    }
-
-    pub fn with_git() -> Self {
-        let mut repo = Self::new();
-        repo.init_git();
-        repo
-    }
-
-    pub fn path(&self) -> &Path {
-        self.dir.path()
-    }
-
-    pub fn init_git(&mut self) {
-        Command::new("git")
-            .args(["init"])
-            .current_dir(self.dir.path())
-            .output()
-            .expect("Failed to init git");
-
-        Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(self.dir.path())
-            .output()
-            .expect("Failed to set git email");
-
-        Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(self.dir.path())
-            .output()
-            .expect("Failed to set git name");
-
-        self.git_initialized = true;
-    }
-
-    pub fn add_file(&self, path: &str, content: &str) -> PathBuf {
-        let full_path = self.dir.path().join(path);
-        if let Some(parent) = full_path.parent() {
-            fs::create_dir_all(parent).expect("Failed to create parent dirs");
-        }
-        fs::write(&full_path, content).expect("Failed to write file");
-
-        if self.git_initialized {
-            Command::new("git")
-                .args(["add", path])
-                .current_dir(self.dir.path())
-                .output()
-                .expect("Failed to git add");
-        }
-
-        full_path
-    }
-
-    pub fn add_untracked(&self, path: &str, content: &str) -> PathBuf {
-        let full_path = self.dir.path().join(path);
-        if let Some(parent) = full_path.parent() {
-            fs::create_dir_all(parent).expect("Failed to create parent dirs");
-        }
-        fs::write(&full_path, content).expect("Failed to write file");
-        full_path
-    }
-
-    pub fn commit(&self, message: &str) {
-        assert!(self.git_initialized, "Git not initialized");
-        Command::new("git")
-            .args(["commit", "-m", message, "--allow-empty"])
-            .current_dir(self.dir.path())
-            .output()
-            .expect("Failed to commit");
-    }
-}
+// Re-export TestRepo from the shared test utilities
+pub use fruit::test_utils::TestRepo;
 
 pub fn run_fruit(dir: &Path, args: &[&str]) -> (String, String, bool) {
     let binary = env!("CARGO_BIN_EXE_fruit");


### PR DESCRIPTION
## Summary

Create a shared `TestRepo` utility in `src/test_utils.rs` that consolidates git repository setup logic:

- Unit tests in `src/git.rs` now use `crate::test_utils::TestRepo`
- Integration tests in `tests/` use `fruit::test_utils::TestRepo`
- Benchmarks in `benches/` use `fruit::test_utils::TestRepo`

The module is gated behind `cfg(test)` for unit tests and a `test-utils` feature flag for integration tests and benchmarks.

## Test plan

- [x] `cargo clippy` passes without warnings
- [x] `cargo test` passes
- [x] `cargo fmt` applied