### PR TITLE
Fix #26: Deduplicate metadata extraction logic

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -704,31 +704,11 @@ impl StreamingWalker {
 
     /// Extract metadata (comments and/or type signatures) from a file.
     fn extract_metadata(&self, path: &Path) -> Option<MetadataBlock> {
-        let mut block = MetadataBlock::new();
-
-        // Extract comments
-        if self.config.extract_comments {
-            if let Some(comment) = extract_first_comment(path) {
-                block.comment_lines = comment
-                    .lines()
-                    .map(|line| MetadataLine::new(line.to_string()))
-                    .collect();
-            }
-        }
-
-        // Extract type signatures
-        if self.config.extract_types {
-            if let Some(signatures) = extract_type_signatures(path) {
-                block.type_lines = signatures
-                    .into_iter()
-                    .map(|(sig, sym, indent)| {
-                        MetadataLine::with_symbol(sig, LineStyle::TypeSignature, sym, indent)
-                    })
-                    .collect();
-            }
-        }
-
-        if block.is_empty() { None } else { Some(block) }
+        extract_metadata_from_path(
+            path,
+            self.config.extract_comments,
+            self.config.extract_types,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Have `StreamingWalker::extract_metadata()` delegate to the free function `extract_metadata_from_path()` instead of duplicating the implementation.

The free function exists for parallel execution (to avoid capturing `&self` which contains non-thread-safe `FileFilter`), and the method now simply calls it with the appropriate config values.

This removes ~20 lines of duplicated code.

## Test plan

- [x] `cargo clippy` passes without warnings
- [x] `cargo test` passes
- [x] `cargo fmt` applied