### PR TITLE
Fix #46: Add --markdown flag for Markdown output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--markdown` / `-m` flag for Markdown output format (#46)
+  - Outputs tree as nested markdown list, ideal for documentation and LLM context
+  - Directories shown in bold (`**name/**`), files in code spans (`` `name` ``)
+  - Comments shown inline or as blockquotes in full mode
+  - Supports combining with `-c`, `-t`, `--todos` for metadata
 - `--todos` flag to extract and display TODO/FIXME/HACK/XXX/BUG/NOTE markers from comments (#45)
   - Shows task markers beneath file entries with line numbers
   - Combines with `-c` to show both comments and TODOs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ pub use metadata::{
     CommentExtractor, LineStyle, MetadataBlock, MetadataConfig, MetadataExtractor, MetadataLine,
     MetadataOrder,
 };
-pub use output::{OutputConfig, StreamingFormatter, TreeFormatter, print_json};
+pub use output::{
+    MarkdownFormatter, OutputConfig, StreamingFormatter, TreeFormatter, print_json, print_markdown,
+};
 pub use todos::{TodoItem, extract_todos};
 pub use tree::{FileFilter, StreamingOutput, StreamingWalker, TreeNode, TreeWalker, WalkerConfig};
 pub use types::{TypeExtractor, extract_type_signatures};

--- a/src/output.rs
+++ b/src/output.rs
@@ -791,6 +791,129 @@ fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
     lines
 }
 
+/// Markdown output formatter - outputs tree as nested markdown list.
+/// Implements the StreamingOutput trait for use with StreamingWalker.
+pub struct MarkdownFormatter {
+    config: OutputConfig,
+    output: String,
+}
+
+impl MarkdownFormatter {
+    pub fn new(config: OutputConfig) -> Self {
+        Self {
+            config,
+            output: String::new(),
+        }
+    }
+
+    /// Get the formatted output string.
+    pub fn output(&self) -> &str {
+        &self.output
+    }
+
+    /// Take ownership of the output string.
+    pub fn into_output(self) -> String {
+        self.output
+    }
+}
+
+impl StreamingOutput for MarkdownFormatter {
+    fn output_node(
+        &mut self,
+        name: &str,
+        metadata: Option<MetadataBlock>,
+        is_dir: bool,
+        _is_last: bool,
+        prefix: &str,
+        is_root: bool,
+    ) -> io::Result<()> {
+        // Calculate indentation level from prefix length
+        // Each level is 2 spaces in markdown list format
+        let indent_level = if is_root { 0 } else { (prefix.len() / 4) + 1 };
+        let indent = "  ".repeat(indent_level);
+
+        if is_dir {
+            // Directories in bold
+            self.output.push_str(&indent);
+            self.output.push_str("- **");
+            self.output.push_str(name);
+            self.output.push_str("/**\n");
+        } else {
+            // Files with optional metadata
+            self.output.push_str(&indent);
+            self.output.push_str("- `");
+            self.output.push_str(name);
+            self.output.push('`');
+
+            // Add metadata if present
+            if let Some(ref block) = metadata {
+                if !block.is_empty() {
+                    let order = self.config.metadata.order;
+
+                    if !self.config.show_full() {
+                        // Inline mode: show first line after filename
+                        if let Some(first) = block.first_line(order) {
+                            self.output.push_str(" - ");
+                            self.output.push_str(first_line(&first.content));
+                        }
+                    } else {
+                        // Full mode: show first line inline, rest as nested content
+                        if let Some(first) = block.first_line(order) {
+                            self.output.push_str(" - ");
+                            self.output.push_str(first_line(&first.content));
+                        }
+
+                        // If there's more than one line, show the rest as a nested block
+                        let lines = block.lines_in_order(order);
+                        if lines.len() > 1 {
+                            self.output.push('\n');
+                            let nested_indent = "  ".repeat(indent_level + 1);
+                            self.output.push_str(&nested_indent);
+                            self.output.push('\n');
+                            self.output.push_str(&nested_indent);
+                            self.output.push_str("> ");
+
+                            // Skip the first line (already shown inline) and format the rest
+                            let remaining: Vec<_> = lines
+                                .iter()
+                                .skip(1)
+                                .filter(|l| !l.content.trim().is_empty())
+                                .collect();
+
+                            for (i, line) in remaining.iter().enumerate() {
+                                if i > 0 {
+                                    self.output.push('\n');
+                                    self.output.push_str(&nested_indent);
+                                    self.output.push_str("> ");
+                                }
+                                self.output.push_str(line.content.trim());
+                            }
+                            self.output.push('\n');
+                        }
+                    }
+                }
+            }
+            self.output.push('\n');
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self, dir_count: usize, file_count: usize) -> io::Result<()> {
+        self.output.push('\n');
+        self.output.push_str(&format!(
+            "*{} directories, {} files*\n",
+            dir_count, file_count
+        ));
+        Ok(())
+    }
+}
+
+/// Print markdown output to stdout.
+pub fn print_markdown(formatter: &MarkdownFormatter) -> io::Result<()> {
+    print!("{}", formatter.output());
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Add `--markdown` / `-m` flag for Markdown output format
- Outputs tree as nested markdown list, ideal for documentation and LLM context
- Directories shown in bold (`**name/**`), files in code spans (`` `name` ``)
- Comments shown inline or as blockquotes in full mode
- Supports combining with `-c`, `-t`, `--todos` for metadata

## Example Output

```markdown
- **src/**
  - `comments.rs` - Source file comment extraction
  - `git.rs` - Git repository integration and gitignore filtering
  - `main.rs` - CLI entry point for fruit

*0 directories, 10 files*
```

With full mode (`-m -f`):
```markdown
- `file.rs` - First line summary
  
  > Additional lines shown as
  > markdown blockquotes
```

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] Manual testing: `fruit --markdown src` produces valid markdown
- [x] Manual testing: `fruit --markdown -f src` shows blockquotes
- [x] Manual testing: `fruit --markdown -t src` shows type signatures