### PR TITLE
Fix #50: Add --newer and --older flags for time-based filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--newer` and `--older` flags to filter files by modification time (#50)
+  - `--newer 1h` shows only files modified within the last hour
+  - `--older 7d` shows only files not modified in the last 7 days
+  - Supports duration formats: `30s`, `5m`, `1h`, `7d`, `2w`, `3M`, `1y`
+  - Combine filters: `--newer 7d --older 1d` for files between 1-7 days old
+  - Useful for finding recently changed code or detecting stale files
 - `--imports` / `-i` flag to show import/dependency statements (#49)
   - Extracts imports from Rust, TypeScript, JavaScript, Python, and Go files
   - Categorizes imports as external (packages), std (standard library), or internal (project)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +145,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +230,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -343,11 +372,13 @@ name = "fruit"
 version = "0.2.0"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
  "criterion",
  "fruit",
  "git2",
  "glob",
+ "humantime",
  "ignore",
  "predicates",
  "rayon",
@@ -426,6 +457,36 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1170,10 +1231,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ default = []
 test-utils = ["dep:tempfile"]
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 git2 = "0.19"
 glob = "0.3.3"
+humantime = "2.1"
 ignore = "0.4"
 rayon = "1.10"
 regex = "1"


### PR DESCRIPTION
## Summary

- Adds `--newer DURATION` flag to show only files modified within the specified duration
- Adds `--older DURATION` flag to show only files NOT modified within the specified duration
- Duration parsing supports multiple formats via `humantime` crate plus custom short syntax

## Duration Formats

| Format | Meaning |
|--------|---------|
| `30s` | 30 seconds |
| `5m` | 5 minutes |
| `1h` | 1 hour |
| `7d` | 7 days |
| `2w` | 2 weeks |
| `3M` | 3 months |
| `1y` | 1 year |
| `"1 hour 30 minutes"` | humantime extended format |

## Examples

```bash
# Files modified in the last hour
fruit --newer 1h .

# Files not modified in 30 days (stale code)
fruit --older 30d .

# Files modified between 1-7 days ago
fruit --newer 7d --older 1d .

# What changed during debugging session?
fruit --newer 2h src/
```

## Implementation

- Added `newer_than` and `older_than` fields to `WalkerConfig` as `Option<SystemTime>`
- Added `passes_time_filter()` helper function to check file mtime
- Integrated time filtering into `should_include_path()`
- Added duration parsing with both `humantime` crate and custom short format support
- Added `chrono` and `humantime` dependencies

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] Manual testing with `--newer 1h` (shows recent files)
- [x] Manual testing with `--older 1h` (excludes recent files)
- [x] Manual testing with combined filters

Closes #50