### PR TITLE
Fix #67: Remove unsafe unwrap() in Go block comment extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Go block comment extraction no longer panics on edge cases with `*/` (#67)
 - `MetadataBlock.total_lines()` now includes import lines in the count (#59)
 - Removed unused `repo_root` field from `GitFilter` struct (#62)
 - Removed unused `LineStyle` variants (`ClassName`, `MethodName`, `Docstring`) from metadata.rs (#57)


### PR DESCRIPTION
## Summary

- Restructure block comment extraction logic to find `/*` first, then look for `*/` after the opening marker
- Eliminates potential panic when `*/` appears in content without a matching `/*`
- Add tests for unclosed block comments and edge cases

## Test plan

- [x] All existing tests pass
- [x] New test `test_go_orphan_close_comment_no_panic` verifies normal case works
- [x] New test `test_go_unclosed_block_comment` verifies unclosed blocks return None
- [x] `cargo clippy` passes without warnings