### PR TITLE
Fix #68: Replace fragile unwrap() in TODO marker extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Go block comment extraction no longer panics on edge cases with `*/` (#67)
+- TODO marker extraction now uses `unwrap_or_else` instead of fragile `unwrap()` (#68)
 - `MetadataBlock.total_lines()` now includes import lines in the count (#59)
 - Removed unused `repo_root` field from `GitFilter` struct (#62)
 - Removed unused `LineStyle` variants (`ClassName`, `MethodName`, `Docstring`) from metadata.rs (#57)

--- a/src/todos.rs
+++ b/src/todos.rs
@@ -124,7 +124,12 @@ fn extract_todos_from_content(content: &str) -> Vec<TodoItem> {
         }
 
         if let Some(caps) = pattern.captures(line) {
-            let marker_type = caps.get(1).map(|m| m.as_str().to_uppercase()).unwrap();
+            // Group 1 contains the marker type (TODO, FIXME, etc.)
+            // Group 2 contains the text after the colon
+            let marker_type = caps
+                .get(1)
+                .map(|m| m.as_str().to_uppercase())
+                .unwrap_or_else(|| "TODO".to_string());
             let text = caps
                 .get(2)
                 .map(|m| m.as_str().trim().to_string())


### PR DESCRIPTION
## Summary

- Replace `unwrap()` with `unwrap_or_else` using "TODO" as a sensible default
- Add comments documenting what each capture group contains
- Provides protection against future regex pattern modifications

## Test plan

- [x] All existing tests pass
- [x] `cargo clippy` passes without warnings