### PR TITLE
Fix #69: Replace test unwrap() with expect() with descriptive message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Go block comment extraction no longer panics on edge cases with `*/` (#67)
 - TODO marker extraction now uses `unwrap_or_else` instead of fragile `unwrap()` (#68)
+- Test code now uses `expect()` with descriptive messages instead of bare `unwrap()` (#69)
 - `MetadataBlock.total_lines()` now includes import lines in the count (#59)
 - Removed unused `repo_root` field from `GitFilter` struct (#62)
 - Removed unused `LineStyle` variants (`ClassName`, `MethodName`, `Docstring`) from metadata.rs (#57)

--- a/src/output.rs
+++ b/src/output.rs
@@ -1229,7 +1229,10 @@ mod tests {
         // Line should just be the filename
         let lines: Vec<&str> = output.lines().collect();
         // Find the line with test.rs
-        let test_line = lines.iter().find(|l| l.contains("test.rs")).unwrap();
+        let test_line = lines
+            .iter()
+            .find(|l| l.contains("test.rs"))
+            .expect("Expected output to contain a line with 'test.rs'");
         // Should end with "test.rs" (possibly with tree connector)
         assert!(
             test_line.trim().ends_with("test.rs"),


### PR DESCRIPTION
## Summary

- Replace bare `unwrap()` with `expect()` including a descriptive message
- Improves test failure diagnostics by explaining what was expected

## Test plan

- [x] All existing tests pass
- [x] `cargo clippy` passes without warnings