### PR TITLE
Fix #75: Document regex unwrap() calls in lazy statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go block comment extraction no longer panics on edge cases with `*/` (#67)
 - TODO marker extraction now uses `unwrap_or_else` instead of fragile `unwrap()` (#68)
 - Test code now uses `expect()` with descriptive messages instead of bare `unwrap()` (#69)
+- Regex `unwrap()` calls in lazy statics now use `expect()` with descriptive messages (#75)
 - `MetadataBlock.total_lines()` now includes import lines in the count (#59)
 - Removed unused `repo_root` field from `GitFilter` struct (#62)
 - Removed unused `LineStyle` variants (`ClassName`, `MethodName`, `Docstring`) from metadata.rs (#57)

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -70,7 +70,8 @@ pub fn extract_imports(path: &Path) -> Option<FileImports> {
 // Rust import extraction
 // =============================================================================
 
-static RUST_USE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^use\s+([^;]+);").unwrap());
+static RUST_USE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^use\s+([^;]+);").expect("RUST_USE regex is invalid"));
 
 fn extract_rust_imports(content: &str) -> Option<FileImports> {
     let mut imports = FileImports::default();
@@ -139,14 +140,19 @@ fn simplify_path(path: &str) -> String {
 // TypeScript/JavaScript import extraction
 // =============================================================================
 
-static TS_IMPORT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"import\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]"#).unwrap());
+static TS_IMPORT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"import\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]"#)
+        .expect("TS_IMPORT regex is invalid")
+});
 
-static JS_REQUIRE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"require\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap());
+static JS_REQUIRE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"require\s*\(\s*['"]([^'"]+)['"]\s*\)"#).expect("JS_REQUIRE regex is invalid")
+});
 
-static TS_EXPORT_FROM: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"export\s+(?:\*|\{[^}]*\})\s+from\s+['"]([^'"]+)['"]"#).unwrap());
+static TS_EXPORT_FROM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"export\s+(?:\*|\{[^}]*\})\s+from\s+['"]([^'"]+)['"]"#)
+        .expect("TS_EXPORT_FROM regex is invalid")
+});
 
 // Node.js built-in modules
 const NODE_BUILTINS: &[&str] = &[
@@ -273,10 +279,12 @@ fn categorize_js_import(module: &str, imports: &mut FileImports) {
 // Python import extraction
 // =============================================================================
 
-static PY_IMPORT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^import\s+(\w+)").unwrap());
+static PY_IMPORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^import\s+(\w+)").expect("PY_IMPORT regex is invalid"));
 
-static PY_FROM_IMPORT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^from\s+(\.*)(\w+)?").unwrap());
+static PY_FROM_IMPORT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^from\s+(\.*)(\w+)?").expect("PY_FROM_IMPORT regex is invalid")
+});
 
 // Python standard library modules (comprehensive list of top-level modules)
 const PYTHON_STDLIB: &[&str] = &[
@@ -529,11 +537,13 @@ fn categorize_python_import(module: &str, _is_from: bool, imports: &mut FileImpo
 // Go import extraction
 // =============================================================================
 
-static GO_IMPORT_SINGLE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"^import\s+"([^"]+)""#).unwrap());
+static GO_IMPORT_SINGLE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^import\s+"([^"]+)""#).expect("GO_IMPORT_SINGLE regex is invalid")
+});
 
-static GO_IMPORT_BLOCK_LINE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"^\s*(?:\w+\s+)?"([^"]+)""#).unwrap());
+static GO_IMPORT_BLOCK_LINE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^\s*(?:\w+\s+)?"([^"]+)""#).expect("GO_IMPORT_BLOCK_LINE regex is invalid")
+});
 
 fn extract_go_imports(content: &str) -> Option<FileImports> {
     let mut imports = FileImports::default();

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,18 +45,24 @@ pub fn extract_type_signatures(path: &Path) -> Option<Vec<(String, String, usize
 // Static regex patterns for each language
 
 // Rust patterns - with capture groups for symbol names
-static RUST_PUB_FN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^pub\s+(async\s+)?fn\s+(\w+)[^{;]*").unwrap());
-static RUST_PUB_STRUCT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^pub\s+struct\s+(\w+)[^{;]*").unwrap());
-static RUST_PUB_ENUM: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^pub\s+enum\s+(\w+)[^{;]*").unwrap());
-static RUST_PUB_TRAIT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^pub\s+trait\s+(\w+)[^{;]*").unwrap());
-static RUST_PUB_TYPE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^pub\s+type\s+(\w+)[^;]+").unwrap());
-static RUST_PUB_CONST: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^pub\s+const\s+(\w+):\s*[^=]+").unwrap());
+static RUST_PUB_FN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^pub\s+(async\s+)?fn\s+(\w+)[^{;]*").expect("RUST_PUB_FN regex is invalid")
+});
+static RUST_PUB_STRUCT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^pub\s+struct\s+(\w+)[^{;]*").expect("RUST_PUB_STRUCT regex is invalid")
+});
+static RUST_PUB_ENUM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^pub\s+enum\s+(\w+)[^{;]*").expect("RUST_PUB_ENUM regex is invalid")
+});
+static RUST_PUB_TRAIT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^pub\s+trait\s+(\w+)[^{;]*").expect("RUST_PUB_TRAIT regex is invalid")
+});
+static RUST_PUB_TYPE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^pub\s+type\s+(\w+)[^;]+").expect("RUST_PUB_TYPE regex is invalid")
+});
+static RUST_PUB_CONST: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^pub\s+const\s+(\w+):\s*[^=]+").expect("RUST_PUB_CONST regex is invalid")
+});
 
 fn extract_rust_signatures(content: &str) -> Option<Vec<(String, String, usize)>> {
     let mut signatures = Vec::new();
@@ -114,18 +120,26 @@ fn extract_rust_signatures(content: &str) -> Option<Vec<(String, String, usize)>
 }
 
 // TypeScript patterns - with capture groups for symbol names
-static TS_EXPORT_FUNCTION: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+(async\s+)?function\s+(\w+)[^{]*").unwrap());
-static TS_EXPORT_INTERFACE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+interface\s+(\w+)[^{]*").unwrap());
-static TS_EXPORT_TYPE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+type\s+(\w+)[^=]*=\s*[^;{]+").unwrap());
-static TS_EXPORT_CLASS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+(abstract\s+)?class\s+(\w+)[^{]*").unwrap());
-static TS_EXPORT_CONST: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+const\s+(\w+):\s*[^=]+").unwrap());
-static TS_EXPORT_ENUM: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+(const\s+)?enum\s+(\w+)[^{]*").unwrap());
+static TS_EXPORT_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+(async\s+)?function\s+(\w+)[^{]*")
+        .expect("TS_EXPORT_FUNCTION regex is invalid")
+});
+static TS_EXPORT_INTERFACE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+interface\s+(\w+)[^{]*").expect("TS_EXPORT_INTERFACE regex is invalid")
+});
+static TS_EXPORT_TYPE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+type\s+(\w+)[^=]*=\s*[^;{]+").expect("TS_EXPORT_TYPE regex is invalid")
+});
+static TS_EXPORT_CLASS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+(abstract\s+)?class\s+(\w+)[^{]*")
+        .expect("TS_EXPORT_CLASS regex is invalid")
+});
+static TS_EXPORT_CONST: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+const\s+(\w+):\s*[^=]+").expect("TS_EXPORT_CONST regex is invalid")
+});
+static TS_EXPORT_ENUM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+(const\s+)?enum\s+(\w+)[^{]*").expect("TS_EXPORT_ENUM regex is invalid")
+});
 
 fn extract_typescript_signatures(content: &str) -> Option<Vec<(String, String, usize)>> {
     let mut signatures = Vec::new();
@@ -179,12 +193,16 @@ fn extract_typescript_signatures(content: &str) -> Option<Vec<(String, String, u
 }
 
 // JavaScript patterns (subset of TypeScript, no type annotations) - with capture groups
-static JS_EXPORT_FUNCTION: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+(async\s+)?function\s+(\w+)\s*\([^)]*\)").unwrap());
-static JS_EXPORT_CLASS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+class\s+(\w+)[^{]*").unwrap());
-static JS_EXPORT_CONST: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^export\s+const\s+(\w+)\s*=").unwrap());
+static JS_EXPORT_FUNCTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+(async\s+)?function\s+(\w+)\s*\([^)]*\)")
+        .expect("JS_EXPORT_FUNCTION regex is invalid")
+});
+static JS_EXPORT_CLASS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+class\s+(\w+)[^{]*").expect("JS_EXPORT_CLASS regex is invalid")
+});
+static JS_EXPORT_CONST: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^export\s+const\s+(\w+)\s*=").expect("JS_EXPORT_CONST regex is invalid")
+});
 
 fn extract_javascript_signatures(content: &str) -> Option<Vec<(String, String, usize)>> {
     let mut signatures = Vec::new();
@@ -223,11 +241,16 @@ fn extract_javascript_signatures(content: &str) -> Option<Vec<(String, String, u
 }
 
 // Python patterns - with capture groups for symbol names
-static PY_DEF_WITH_RETURN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^def\s+(\w+)\s*\([^)]*\)\s*->\s*[^:]+").unwrap());
-static PY_ASYNC_DEF_WITH_RETURN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^async\s+def\s+(\w+)\s*\([^)]*\)\s*->\s*[^:]+").unwrap());
-static PY_CLASS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^class\s+(\w+)[^:]*").unwrap());
+static PY_DEF_WITH_RETURN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^def\s+(\w+)\s*\([^)]*\)\s*->\s*[^:]+")
+        .expect("PY_DEF_WITH_RETURN regex is invalid")
+});
+static PY_ASYNC_DEF_WITH_RETURN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^async\s+def\s+(\w+)\s*\([^)]*\)\s*->\s*[^:]+")
+        .expect("PY_ASYNC_DEF_WITH_RETURN regex is invalid")
+});
+static PY_CLASS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^class\s+(\w+)[^:]*").expect("PY_CLASS regex is invalid"));
 
 fn extract_python_signatures(content: &str) -> Option<Vec<(String, String, usize)>> {
     let mut signatures = Vec::new();
@@ -274,16 +297,22 @@ fn extract_python_signatures(content: &str) -> Option<Vec<(String, String, usize
 }
 
 // Go patterns - exported items start with uppercase - with capture groups
-static GO_EXPORTED_FUNC: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^func\s+([A-Z]\w*)\s*\([^)]*\)[^{]*").unwrap());
-static GO_EXPORTED_METHOD: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^func\s+\([^)]+\)\s*([A-Z]\w*)\s*\([^)]*\)[^{]*").unwrap());
-static GO_EXPORTED_TYPE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^type\s+([A-Z]\w*)\s+\w+").unwrap());
-static GO_EXPORTED_CONST: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^const\s+([A-Z]\w*)\s*[^=]*=").unwrap());
-static GO_EXPORTED_VAR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^var\s+([A-Z]\w*)\s+\w+").unwrap());
+static GO_EXPORTED_FUNC: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^func\s+([A-Z]\w*)\s*\([^)]*\)[^{]*").expect("GO_EXPORTED_FUNC regex is invalid")
+});
+static GO_EXPORTED_METHOD: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^func\s+\([^)]+\)\s*([A-Z]\w*)\s*\([^)]*\)[^{]*")
+        .expect("GO_EXPORTED_METHOD regex is invalid")
+});
+static GO_EXPORTED_TYPE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^type\s+([A-Z]\w*)\s+\w+").expect("GO_EXPORTED_TYPE regex is invalid")
+});
+static GO_EXPORTED_CONST: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^const\s+([A-Z]\w*)\s*[^=]*=").expect("GO_EXPORTED_CONST regex is invalid")
+});
+static GO_EXPORTED_VAR: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^var\s+([A-Z]\w*)\s+\w+").expect("GO_EXPORTED_VAR regex is invalid")
+});
 
 fn extract_go_signatures(content: &str) -> Option<Vec<(String, String, usize)>> {
     let mut signatures = Vec::new();


### PR DESCRIPTION
## Summary

Replace all regex `unwrap()` calls with `expect()` messages that identify the specific regex pattern that failed. This improves debugging when regex patterns are modified incorrectly.

Updated files:
- `src/imports.rs`: 8 regex patterns
- `src/types.rs`: 19 regex patterns

## Test plan

- [x] All existing tests pass (101 unit tests, 50+ integration tests)
- [x] `cargo clippy` passes without warnings
- [x] No functional changes - only error messages improved