### PR TITLE
Fix #76: Add --max-file-size flag for configurable extraction limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--max-file-size` flag to configure maximum file size for metadata extraction (#76)
+  - Default remains 1MB, use suffixes like `5M`, `100K`, `1G` to customize
+  - Files larger than the limit are skipped to prevent excessive memory usage
+  - Example: `fruit --max-file-size 5M` to allow files up to 5MB
+
 ### Changed
 
 - Simplified duration parsing to use `humantime` crate directly, removing redundant custom parsing (#64)


### PR DESCRIPTION
## Summary
- Adds `--max-file-size` CLI flag to configure maximum file size for metadata extraction
- Supports size suffixes: K/KB (1024), M/MB (1024^2), G/GB (1024^3)
- Uses atomic global to allow runtime configuration while maintaining thread safety
- Default remains 1MB to maintain backwards compatibility

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `fruit --help` shows new flag
- [x] `fruit --max-file-size 5M .` works correctly