### PR TITLE
Fix #72: Improve test utilities expect() messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test code now uses `expect()` with descriptive messages instead of bare `unwrap()` (#69)
 - Regex `unwrap()` calls in lazy statics now use `expect()` with descriptive messages (#75)
 - Go block comment extraction now correctly handles multiple block comments (#74)
+- Test utilities now use descriptive panic messages with context (method name, paths, errors) (#72)
 - `MetadataBlock.total_lines()` now includes import lines in the count (#59)
 - Removed unused `repo_root` field from `GitFilter` struct (#62)
 - Removed unused `LineStyle` variants (`ClassName`, `MethodName`, `Docstring`) from metadata.rs (#57)


### PR DESCRIPTION
## Summary
- Add method name prefix to all panic messages (e.g., `TestRepo::init_git:`)
- Include file paths in error messages for file operations
- Include actual error messages in panic output
- Use `unwrap_or_else` to format dynamic error messages

These changes make test setup failures much easier to debug by providing context about what operation failed and where.

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean