### PR TITLE
Fix #93: Make extension matching case-insensitive

### DIFF
--- a/src/comments.rs
+++ b/src/comments.rs
@@ -61,16 +61,17 @@ use crate::file_utils::read_source_file;
 pub fn extract_first_comment(path: &Path) -> Option<String> {
     let (content, extension) = read_source_file(path)?;
 
+    // Extension is already normalized to lowercase by read_source_file
     match extension {
         "rs" => extract_rust_comment(&content),
         "py" => extract_python_docstring(&content),
-        "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => extract_js_comment(&content),
+        "js" | "ts" => extract_js_comment(&content),
         "go" => extract_go_comment(&content),
-        "c" | "h" | "cpp" | "hpp" | "cc" | "cxx" => extract_c_comment(&content),
+        "c" | "cpp" => extract_c_comment(&content),
         "rb" => extract_ruby_comment(&content),
-        "sh" | "bash" | "zsh" => extract_shell_comment(&content),
+        "sh" => extract_shell_comment(&content),
         // Java, Kotlin, Swift use JavaDoc-style /** */ comments
-        "java" | "kt" | "kts" | "swift" => extract_javadoc_comment(&content),
+        "java" | "kt" | "swift" => extract_javadoc_comment(&content),
         // PHP uses PHPDoc /** */ and also # comments
         "php" => extract_php_comment(&content),
         // C# uses /// XML doc comments

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -24,16 +24,89 @@ pub fn get_max_file_size() -> u64 {
     MAX_FILE_SIZE.load(Ordering::SeqCst)
 }
 
+/// Normalize a file extension to lowercase for case-insensitive matching.
+///
+/// Returns a static string reference for recognized extensions,
+/// normalizing variants to their canonical form (e.g., ".RS" -> "rs").
+/// Returns `None` for unrecognized extensions.
+pub fn normalize_extension(ext: &str) -> Option<&'static str> {
+    let ext_lower = ext.to_lowercase();
+    match ext_lower.as_str() {
+        // Rust
+        "rs" => Some("rs"),
+        // Python
+        "py" | "pyw" | "pyi" => Some("py"),
+        // JavaScript
+        "js" | "jsx" | "mjs" | "cjs" => Some("js"),
+        // TypeScript
+        "ts" | "tsx" | "mts" | "cts" => Some("ts"),
+        // Go
+        "go" => Some("go"),
+        // C
+        "c" | "h" => Some("c"),
+        // C++
+        "cpp" | "cxx" | "cc" | "hpp" | "hxx" | "hh" => Some("cpp"),
+        // C#
+        "cs" => Some("cs"),
+        // Java
+        "java" => Some("java"),
+        // Ruby
+        "rb" => Some("rb"),
+        // PHP
+        "php" => Some("php"),
+        // Shell
+        "sh" | "bash" | "zsh" | "fish" => Some("sh"),
+        // Swift
+        "swift" => Some("swift"),
+        // Kotlin
+        "kt" | "kts" => Some("kt"),
+        // Scala
+        "scala" | "sc" => Some("scala"),
+        // Lua
+        "lua" => Some("lua"),
+        // Perl
+        "pl" | "pm" => Some("pl"),
+        // R
+        "r" => Some("r"),
+        // Julia
+        "jl" => Some("jl"),
+        // Dart
+        "dart" => Some("dart"),
+        // Elixir
+        "ex" | "exs" => Some("ex"),
+        // Erlang
+        "erl" | "hrl" => Some("erl"),
+        // Haskell
+        "hs" | "lhs" => Some("hs"),
+        // OCaml
+        "ml" | "mli" => Some("ml"),
+        // F#
+        "fs" | "fsi" | "fsx" => Some("fs"),
+        // Clojure
+        "clj" | "cljs" | "cljc" | "edn" => Some("clj"),
+        // Zig
+        "zig" => Some("zig"),
+        // Vue
+        "vue" => Some("vue"),
+        // Svelte
+        "svelte" => Some("svelte"),
+        // Unrecognized extension
+        _ => None,
+    }
+}
+
 /// Read a source file if it meets size requirements.
 ///
 /// Returns `None` if:
 /// - File is larger than the configured MAX_FILE_SIZE
 /// - File has no extension
 /// - Extension is not valid UTF-8
+/// - Extension is not a recognized source file type
 /// - File cannot be read
 ///
 /// Returns `Some((content, extension))` on success.
-pub fn read_source_file(path: &Path) -> Option<(String, &str)> {
+/// The extension is normalized to lowercase for case-insensitive matching.
+pub fn read_source_file(path: &Path) -> Option<(String, &'static str)> {
     // Check file size first
     if let Ok(metadata) = path.metadata() {
         if metadata.len() > get_max_file_size() {
@@ -41,13 +114,14 @@ pub fn read_source_file(path: &Path) -> Option<(String, &str)> {
         }
     }
 
-    // Get extension
+    // Get extension and normalize to lowercase
     let extension = path.extension()?.to_str()?;
+    let ext_static = normalize_extension(extension)?;
 
     // Read content
     let content = std::fs::read_to_string(path).ok()?;
 
-    Some((content, extension))
+    Some((content, ext_static))
 }
 
 #[cfg(test)]
@@ -83,5 +157,67 @@ mod tests {
     fn test_read_source_file_nonexistent() {
         let result = read_source_file(Path::new("/nonexistent/file.rs"));
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_source_file_case_insensitive() {
+        let dir = TempDir::new().unwrap();
+
+        // Test uppercase extension
+        let file_path = dir.path().join("test.RS");
+        fs::write(&file_path, "fn main() {}").unwrap();
+        let result = read_source_file(&file_path);
+        assert!(result.is_some(), "should recognize .RS as .rs");
+        let (_, ext) = result.unwrap();
+        assert_eq!(ext, "rs", "extension should be normalized to lowercase");
+
+        // Test mixed case extension
+        let file_path = dir.path().join("test.Py");
+        fs::write(&file_path, "print('hello')").unwrap();
+        let result = read_source_file(&file_path);
+        assert!(result.is_some(), "should recognize .Py as .py");
+        let (_, ext) = result.unwrap();
+        assert_eq!(ext, "py", "extension should be normalized to lowercase");
+    }
+
+    #[test]
+    fn test_normalize_extension() {
+        // Basic lowercase
+        assert_eq!(normalize_extension("rs"), Some("rs"));
+        assert_eq!(normalize_extension("py"), Some("py"));
+
+        // Uppercase
+        assert_eq!(normalize_extension("RS"), Some("rs"));
+        assert_eq!(normalize_extension("PY"), Some("py"));
+        assert_eq!(normalize_extension("JS"), Some("js"));
+
+        // Mixed case
+        assert_eq!(normalize_extension("Py"), Some("py"));
+        assert_eq!(normalize_extension("rS"), Some("rs"));
+
+        // Variants normalized to canonical form
+        assert_eq!(normalize_extension("jsx"), Some("js"));
+        assert_eq!(normalize_extension("JSX"), Some("js"));
+        assert_eq!(normalize_extension("tsx"), Some("ts"));
+        assert_eq!(normalize_extension("TSX"), Some("ts"));
+        assert_eq!(normalize_extension("hpp"), Some("cpp"));
+        assert_eq!(normalize_extension("HPP"), Some("cpp"));
+
+        // Unknown extension
+        assert_eq!(normalize_extension("xyz"), None);
+        assert_eq!(normalize_extension("XYZ"), None);
+    }
+
+    #[test]
+    fn test_read_source_file_unrecognized_extension() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("data.xyz");
+        fs::write(&file_path, "some data").unwrap();
+
+        let result = read_source_file(&file_path);
+        assert!(
+            result.is_none(),
+            "unrecognized extension should return None"
+        );
     }
 }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -54,10 +54,11 @@ impl FileImports {
 pub fn extract_imports(path: &Path) -> Option<FileImports> {
     let (content, extension) = read_source_file(path)?;
 
+    // Extension is already normalized to lowercase by read_source_file
     let imports = match extension {
         "rs" => extract_rust_imports(&content),
-        "ts" | "tsx" | "mts" | "cts" => extract_typescript_imports(&content),
-        "js" | "jsx" | "mjs" | "cjs" => extract_javascript_imports(&content),
+        "ts" => extract_typescript_imports(&content),
+        "js" => extract_javascript_imports(&content),
         "py" => extract_python_imports(&content),
         "go" => extract_go_imports(&content),
         _ => None,
@@ -282,9 +283,8 @@ fn categorize_js_import(module: &str, imports: &mut FileImports) {
 static PY_IMPORT: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^import\s+(\w+)").expect("PY_IMPORT regex is invalid"));
 
-static PY_FROM_IMPORT: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^from\s+(\.*)(\w+)?").expect("PY_FROM_IMPORT regex is invalid")
-});
+static PY_FROM_IMPORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^from\s+(\.*)(\w+)?").expect("PY_FROM_IMPORT regex is invalid"));
 
 // Python standard library modules (comprehensive list of top-level modules)
 const PYTHON_STDLIB: &[&str] = &[

--- a/src/todos.rs
+++ b/src/todos.rs
@@ -41,66 +41,12 @@ pub struct TodoItem {
 /// - `FIXME - memory leak` → type="FIXME", text="memory leak"
 /// - `// TODO: implement` → type="TODO", text="implement"
 pub fn extract_todos(path: &Path) -> Option<Vec<TodoItem>> {
-    let (content, extension) = read_source_file(path)?;
-
-    // Only process files with recognized extensions
-    if !is_supported_extension(extension) {
-        return None;
-    }
+    // read_source_file handles extension filtering and case-normalization
+    let (content, _extension) = read_source_file(path)?;
 
     let todos = extract_todos_from_content(&content);
 
     if todos.is_empty() { None } else { Some(todos) }
-}
-
-/// Check if an extension is supported for TODO extraction.
-fn is_supported_extension(ext: &str) -> bool {
-    matches!(
-        ext,
-        "rs" | "py"
-            | "js"
-            | "jsx"
-            | "ts"
-            | "tsx"
-            | "mjs"
-            | "cjs"
-            | "go"
-            | "c"
-            | "h"
-            | "cpp"
-            | "hpp"
-            | "cc"
-            | "cxx"
-            | "rb"
-            | "sh"
-            | "bash"
-            | "zsh"
-            | "java"
-            | "kt"
-            | "kts"
-            | "swift"
-            | "php"
-            | "cs"
-            | "lua"
-            | "pl"
-            | "pm"
-            | "r"
-            | "R"
-            | "scala"
-            | "clj"
-            | "cljs"
-            | "ex"
-            | "exs"
-            | "erl"
-            | "hrl"
-            | "hs"
-            | "ml"
-            | "mli"
-            | "fs"
-            | "fsx"
-            | "vue"
-            | "svelte"
-    )
 }
 
 /// Extract TODO items from file content.

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,10 +30,11 @@ fn calculate_indent(line: &str) -> usize {
 pub fn extract_type_signatures(path: &Path) -> Option<Vec<(String, String, usize)>> {
     let (content, extension) = read_source_file(path)?;
 
+    // Extension is already normalized to lowercase by read_source_file
     let signatures = match extension {
         "rs" => extract_rust_signatures(&content),
-        "ts" | "tsx" | "mts" | "cts" => extract_typescript_signatures(&content),
-        "js" | "jsx" | "mjs" | "cjs" => extract_javascript_signatures(&content),
+        "ts" => extract_typescript_signatures(&content),
+        "js" => extract_javascript_signatures(&content),
         "py" => extract_python_signatures(&content),
         "go" => extract_go_signatures(&content),
         _ => None,


### PR DESCRIPTION
## Summary
Normalize file extensions to lowercase for consistent matching across different file systems (macOS and Windows are case-insensitive by default).

Changes:
- Add `normalize_extension()` function that maps extensions to lowercase canonical forms
- Update `read_source_file()` to return normalized extension as `&'static str`
- Simplify match statements in comments.rs, types.rs, imports.rs
- Remove redundant `is_supported_extension()` from todos.rs
- Add comprehensive tests for case-insensitive extension handling

This means files like `Main.RS`, `script.PY`, `app.JSX` will now be correctly processed.

## Test plan
- [x] `test_normalize_extension` - Verifies case normalization for various extensions
- [x] `test_read_source_file_case_insensitive` - Verifies uppercase/mixed case files are recognized
- [x] `test_read_source_file_unrecognized_extension` - Verifies unknown extensions return None
- [x] All existing tests pass (no regressions)

Closes #93