### PR TITLE
Fix #92: Fix inconsistent parallel mode fallback in streaming.rs

### DIFF
--- a/src/tree/streaming.rs
+++ b/src/tree/streaming.rs
@@ -177,8 +177,12 @@ impl StreamingWalker {
                             })
                             .collect()
                     }),
-                    Err(_) => {
-                        // Fall back to rayon's global pool if custom pool creation fails
+                    Err(e) => {
+                        // Warn user and fall back to rayon's global pool
+                        eprintln!(
+                            "fruit: warning: failed to create thread pool with {} workers ({}), using default pool",
+                            self.config.parallel_workers, e
+                        );
                         file_indices
                             .par_iter()
                             .map(|&i| {


### PR DESCRIPTION
## Summary
Add warning message when custom thread pool creation fails and the code falls back to rayon's global pool.

Previously, when `rayon::ThreadPoolBuilder::new().num_threads(N).build()` failed, the code silently fell back to rayon's global pool. This meant users who explicitly set `-j N` would have their preference ignored without any indication.

Now outputs: `fruit: warning: failed to create thread pool with N workers (error), using default pool`

## Test plan
- [x] Code compiles and builds correctly
- [x] Existing tests pass

Note: This is a simple UX improvement that adds a warning message. The actual thread pool fallback behavior is unchanged, making this low-risk.

Closes #92