### PR TITLE
Fix #88: Deduplicate metadata block printing logic

### DIFF
--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -6,13 +6,13 @@
 use std::io::{self, Write};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use crate::metadata::{MetadataBlock, MetadataLine};
+use crate::metadata::MetadataBlock;
 use crate::tree::StreamingOutput;
 
 use super::config::OutputConfig;
 use super::utils::{
-    calculate_wrap_width, continuation_prefix, first_line, has_indented_children,
-    should_insert_group_separator, wrap_text, write_metadata_line_with_symbol,
+    calculate_wrap_width, continuation_prefix, render_metadata_block, write_metadata_line_with_symbol,
+    MetadataRenderResult, RenderedLine,
 };
 
 /// Streaming output formatter - outputs directly to stdout without buffering.
@@ -35,82 +35,50 @@ impl StreamingFormatter {
         }
     }
 
-    /// Write inline metadata (first line only, on same line as filename).
-    fn write_inline_metadata(
+    /// Write a rendered line with colors.
+    fn write_rendered_line(
         &mut self,
-        meta_prefix: &str,
-        first: &MetadataLine,
-    ) -> io::Result<()> {
-        write!(self.stdout, "  {}", meta_prefix)?;
-        write_metadata_line_with_symbol(
-            &mut self.stdout,
-            first_line(&first.content),
-            first.symbol_name.as_deref(),
-            first.style.color(),
-            first.style.is_intense(),
-            first.indent,
-        )?;
-        writeln!(self.stdout)?;
-        self.stdout.reset()?;
-        Ok(())
-    }
-
-    /// Print metadata lines in a block format with proper indentation and group separators.
-    fn print_metadata_lines_block(
-        &mut self,
-        lines: &[&MetadataLine],
+        line: &RenderedLine,
         cont_prefix: &str,
         meta_prefix: &str,
-        wrap_width: Option<usize>,
     ) -> io::Result<()> {
-        // Blank line before block
-        self.stdout.reset()?;
-        writeln!(self.stdout, "{}", cont_prefix)?;
-
-        let mut prev_indent: Option<usize> = None;
-        for (i, meta_line) in lines.iter().enumerate() {
-            let content = meta_line.content.trim();
-
-            // Empty line is a separator between sections
-            if content.is_empty() {
-                self.stdout.reset()?;
-                writeln!(self.stdout, "{}", cont_prefix)?;
-                prev_indent = None;
-                continue;
-            }
-
-            // Check if we should insert a group separator
-            let has_children = has_indented_children(&lines[i + 1..], meta_line.indent);
-            if should_insert_group_separator(meta_line.indent, prev_indent, has_children) {
+        match line {
+            RenderedLine::Separator => {
                 self.stdout.reset()?;
                 writeln!(self.stdout, "{}", cont_prefix)?;
             }
-            prev_indent = Some(meta_line.indent);
-
-            let wrapped = if let Some(width) = wrap_width {
-                wrap_text(content, width)
-            } else {
-                vec![content.to_string()]
-            };
-
-            for wrapped_line in wrapped.iter() {
+            RenderedLine::Content { text, symbol_name, style, indent } => {
                 self.stdout.reset()?;
                 write!(self.stdout, "{}{}", cont_prefix, meta_prefix)?;
                 write_metadata_line_with_symbol(
                     &mut self.stdout,
-                    wrapped_line,
-                    meta_line.symbol_name.as_deref(),
-                    meta_line.style.color(),
-                    meta_line.style.is_intense(),
-                    meta_line.indent,
+                    text,
+                    symbol_name.as_deref(),
+                    style.color(),
+                    style.is_intense(),
+                    *indent,
                 )?;
                 writeln!(self.stdout)?;
             }
         }
+        Ok(())
+    }
 
-        // Blank line after block
-        self.stdout.reset()?;
-        writeln!(self.stdout, "{}", cont_prefix)?;
+    /// Write inline content (first line on same line as filename).
+    fn write_inline_content(&mut self, line: &RenderedLine, meta_prefix: &str) -> io::Result<()> {
+        if let RenderedLine::Content { text, symbol_name, style, indent } = line {
+            write!(self.stdout, "  {}", meta_prefix)?;
+            write_metadata_line_with_symbol(
+                &mut self.stdout,
+                text,
+                symbol_name.as_deref(),
+                style.color(),
+                style.is_intense(),
+                *indent,
+            )?;
+            writeln!(self.stdout)?;
+            self.stdout.reset()?;
+        }
         Ok(())
     }
 
@@ -121,75 +89,41 @@ impl StreamingFormatter {
         prefix: &str,
         is_last: bool,
     ) -> io::Result<()> {
-        if block.is_empty() {
-            writeln!(self.stdout)?;
-            return Ok(());
-        }
-
-        // Copy config values to avoid borrow conflicts
         let meta_prefix = self.config.metadata.prefix_str().to_string();
         let order = self.config.metadata.order;
-        let base_wrap_width = self.config.wrap_width;
         let show_full = self.config.show_full();
-
-        // Check if the first section (based on order) is a single line
-        let first_is_single = block.first_section_is_single_line(order);
-        let total_lines = block.total_lines();
-
-        // Not in full mode: show first line inline only
-        if !show_full {
-            if let Some(first) = block.first_line(order) {
-                self.write_inline_metadata(&meta_prefix, first)?;
-            } else {
-                writeln!(self.stdout)?;
-            }
-            return Ok(());
-        }
-
-        // Full mode: show all metadata
-        let lines = block.lines_in_order(order);
-
-        // If total is just 1 line, show inline
-        if total_lines == 1 {
-            if let Some(first) = block.first_line(order) {
-                self.write_inline_metadata(&meta_prefix, first)?;
-            } else {
-                writeln!(self.stdout)?;
-            }
-            return Ok(());
-        }
 
         let cont_prefix = continuation_prefix(prefix, is_last);
         let wrap_width = calculate_wrap_width(
-            base_wrap_width,
+            self.config.wrap_width,
             cont_prefix.chars().count(),
             meta_prefix.chars().count(),
         );
 
-        // If first section is single line and there's more content, show first inline then rest below
-        if first_is_single {
-            if let Some(first) = block.first_line(order) {
-                self.write_inline_metadata(&meta_prefix, first)?;
+        let result = render_metadata_block(block, order, show_full, wrap_width);
+
+        match result {
+            MetadataRenderResult::Empty => {
+                writeln!(self.stdout)?;
             }
-
-            // Skip the first line (already shown inline) and the separator after it
-            let skip_count = if block.has_both() { 2 } else { 1 };
-            let remaining_lines: Vec<_> = lines.iter().skip(skip_count).collect();
-            self.print_metadata_lines_block(
-                &remaining_lines,
-                &cont_prefix,
-                &meta_prefix,
-                wrap_width,
-            )?;
-        } else {
-            // First section has multiple lines, show everything below
-            writeln!(self.stdout)?; // End the filename line
-
-            let line_refs: Vec<_> = lines.iter().collect();
-            self.print_metadata_lines_block(&line_refs, &cont_prefix, &meta_prefix, wrap_width)?;
+            MetadataRenderResult::Inline { first } => {
+                self.write_inline_content(&first, &meta_prefix)?;
+            }
+            MetadataRenderResult::InlineWithBlock { first, block_lines } => {
+                self.write_inline_content(&first, &meta_prefix)?;
+                for line in &block_lines {
+                    self.write_rendered_line(line, &cont_prefix, &meta_prefix)?;
+                }
+                self.stdout.reset()?;
+            }
+            MetadataRenderResult::Block { lines } => {
+                writeln!(self.stdout)?; // End the filename line
+                for line in &lines {
+                    self.write_rendered_line(line, &cont_prefix, &meta_prefix)?;
+                }
+                self.stdout.reset()?;
+            }
         }
-
-        self.stdout.reset()?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Extract shared rendering logic into `RenderedLine` enum and `render_metadata_block()` function
- Add `MetadataRenderResult` enum for Empty/Inline/InlineWithBlock/Block display modes
- Update both `TreeFormatter` and `StreamingFormatter` to use the new abstraction

## Changes

The core logic for:
- Checking if block is empty
- Determining inline vs block display
- Calculating wrap widths
- Printing lines with group separators
- Handling metadata order

...is now centralized in `render_metadata_block()` instead of being duplicated across:
- `TreeFormatter::print_metadata_block()` (colored output)
- `TreeFormatter::format_metadata_block_plain()` (plain text output)
- `StreamingFormatter::print_metadata_block()` (streaming colored output)

This reduces ~200 lines of duplicated logic to a single shared implementation.

## Test plan
- [x] All existing tests pass
- [x] `cargo clippy` passes
- [x] Output behavior is unchanged (verified through existing tests)