### PR TITLE
Fix #87: Handle Args::from_arg_matches() error gracefully

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,10 @@ fn get_metadata_order(matches: &ArgMatches) -> MetadataOrder {
 
 fn main() {
     let matches = Args::command().get_matches();
-    let args = Args::from_arg_matches(&matches).unwrap();
+    let args = Args::from_arg_matches(&matches).unwrap_or_else(|e| {
+        eprintln!("fruit: argument parsing error: {}", e);
+        process::exit(1);
+    });
 
     // Configure max file size for extraction if specified
     if let Some(ref size_str) = args.max_file_size {


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` with `.unwrap_or_else()` for `Args::from_arg_matches()`
- Display a user-friendly error message instead of a panic trace

## Before
```
thread 'main' panicked at src/main.rs:216:47:
called `Result::unwrap()` on an `Err` value: ...
```

## After
```
fruit: argument parsing error: ...
```

## Test plan
- [x] All tests pass
- [x] `cargo clippy` passes